### PR TITLE
Default ether allowance to MAX_UINT. Also now correctly refreshes sta…

### DIFF
--- a/src/stores/Provider.ts
+++ b/src/stores/Provider.ts
@@ -106,6 +106,19 @@ export default class ProviderStore {
             account,
             contractMetadataStore.getTrackedTokenAddresses()
         );
+
+        if (tokenStore.inputToken.address !== 'unknown')
+            tokenStore.setSelectedTokenMetadata(
+                true,
+                tokenStore.inputToken.address,
+                account
+            );
+        if (tokenStore.outputToken.address !== 'unknown')
+            tokenStore.setSelectedTokenMetadata(
+                false,
+                tokenStore.outputToken.address,
+                account
+            );
     };
 
     // account is optional

--- a/src/stores/Token.ts
+++ b/src/stores/Token.ts
@@ -5,7 +5,7 @@ import * as helpers from 'utils/helpers';
 import { bnum, formatBalanceTruncated } from 'utils/helpers';
 import { FetchCode } from './Transaction';
 import { BigNumber } from 'utils/bignumber';
-import { isAddress } from 'utils/helpers';
+import { isAddress, MAX_UINT } from 'utils/helpers';
 import { Interface } from 'ethers/utils';
 import { getSupportedChainName } from '../provider/connectors';
 import * as ethers from 'ethers';
@@ -367,6 +367,7 @@ export default class TokenStore {
         const chainApprovals = this.allowances;
         if (chainApprovals) {
             const tokenApprovals = chainApprovals[tokenAddress];
+
             if (tokenApprovals) {
                 const userApprovals = tokenApprovals[account];
                 if (userApprovals) {
@@ -449,7 +450,7 @@ export default class TokenStore {
     }
 
     fetchOnChainTokenMetadata = async (address: string, account: string) => {
-        console.log(`[Token] fetchOnChainTokenMetadata: ${address}`);
+        console.log(`[Token] fetchOnChainTokenMetadata: ${address} ${account}`);
 
         let iconAddress;
 
@@ -486,12 +487,6 @@ export default class TokenStore {
                     20
                 );
 
-                let allowance = this.getAllowance(
-                    address,
-                    account,
-                    proxyAddress
-                );
-
                 tokenMetadata = {
                     address: address,
                     symbol: 'ETH',
@@ -500,7 +495,7 @@ export default class TokenStore {
                     precision: 4,
                     balanceBn: bnum(balanceWei),
                     balanceFormatted: balanceFormatted,
-                    allowance: allowance,
+                    allowance: MAX_UINT,
                 };
             }
         } else {


### PR DESCRIPTION
Ether allowance was being loaded from whitelist store. On first load this was sometimes happening before the store had updated and the allowance would show as undefined causing Unlock button to show. Now manually set SwapForm eth allowance to MAX_UINT (same as whitelist store).

Also noticed balances, etc weren't refreshing on succesful transaction so this has been corrected.