### PR TITLE
[deployed.json] Add JRT ERC20 to the list

### DIFF
--- a/src/deployed.json
+++ b/src/deployed.json
@@ -339,6 +339,13 @@
                 "decimals": 18,
                 "iconAddress": "0x985dd3D42De1e256d09e1c10F112bCCB8015AD41",
                 "precision": 2
+            },
+            {
+                "symbol": "JRT",
+                "address": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
+                "decimals": 18,
+                "iconAddress": "0x8A9C67fee641579dEbA04928c4BC45F66e26343A",
+                "precision": 2
             }
         ]
     }


### PR DESCRIPTION
Additional info:
* Token address: [0x8A9C67fee641579dEbA04928c4BC45F66e26343A][1] (OpenZeppelin Proxy)
* Token Implementation address: [0x082582c4271f3f6dd5f4306cbcac822076516c53][2]  (OpenZeppelin ERC20)
* Token Name: Jarvis Reward Token
* Token Decimals: 18
* Token Symbol: JRT
* Project Website: https://jarvis.network/
* CoinGecko: https://www.coingecko.com/en/coins/jarvis-reward-token
* CoinMarketCap: https://coinmarketcap.com/currencies/jarvis-network/
* Medium: https://medium.com/jarvis-network

Created pools so far:
- JRT 90% WETH 10%: https://pools.balancer.exchange/#/pool/0x68198e4ed6975204b3467dc217166d9ff1cbb57a
- JRT 90% USDC 10%: https://pools.balancer.exchange/#/pool/0x01d7e6a79f6e6dc6f0884743078f76ac1239520a
- JRT 70% SNX 30%: https://pools.balancer.exchange/#/pool/0xd21ae4b071055a3294a9f41b34fa0b7f1ffba647
- JRT 90% DAI 10%: https://pools.balancer.exchange/#/pool/0x49e4cb1bebc5a060505d4571ec50bd2b65c3ed11
- JRT 70% COMP 30%: https://pools.balancer.exchange/#/pool/0xf984bb6ca32f452bb21ddbfa99ec62dc4ce35c2d

[1]: https://etherscan.io/token/0x8a9c67fee641579deba04928c4bc45f66e26343a
[2]: https://etherscan.io/address/0x082582c4271f3f6dd5f4306cbcac822076516c53#code