### PR TITLE
John/bal issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "tslint-react": "^4.1.0",
         "typescript": "<3.7.0",
         "url-loader": "2.1.0",
-        "web3modal": "^1.2.1",
+        "web3modal": "^1.7.0",
         "webpack": "4.41.0",
         "webpack-dev-server": "3.2.1",
         "webpack-manifest-plugin": "2.1.1",

--- a/src/components/AssetOptions.tsx
+++ b/src/components/AssetOptions.tsx
@@ -217,6 +217,10 @@ const AssetOptions = observer(() => {
         }
     };
 
+    const IconError = e => {
+        e.target.src = './empty-token.png';
+    };
+
     return (
         <AssetPanelContainer>
             {assets.map(token => (
@@ -227,7 +231,12 @@ const AssetOptions = observer(() => {
                     key={token.address}
                 >
                     <AssetWrapper>
-                        <TokenIcon src={TokenIconAddress(token.iconAddress)} />
+                        <TokenIcon
+                            src={TokenIconAddress(token.iconAddress)}
+                            onError={e => {
+                                IconError(e);
+                            }}
+                        />
                         <TokenName>{token.symbol}</TokenName>
                     </AssetWrapper>
                     <TokenBalance>

--- a/src/components/AssetSelector.tsx
+++ b/src/components/AssetSelector.tsx
@@ -140,8 +140,8 @@ const AssetSelector = observer(() => {
                     <HeaderContent>
                         Select Token to{' '}
                         {assetModalState.type === ModalType.INPUT
-                            ? 'Sell'
-                            : 'Buy'}
+                            ? `Sell for ${swapFormStore.outputToken.symbol}`
+                            : `Buy with ${swapFormStore.inputToken.symbol}`}
                     </HeaderContent>
                     <ExitComponent
                         onClick={() => {

--- a/src/components/AssetSelector.tsx
+++ b/src/components/AssetSelector.tsx
@@ -119,6 +119,11 @@ const AssetSelector = observer(() => {
     } = useStores();
 
     const ref = useRef();
+    const inputRef = useRef(null);
+
+    useEffect(() => {
+        if (inputRef !== null) inputRef.current.focus();
+    });
 
     useOnClickOutside(ref, () => swapFormStore.closeModal());
 
@@ -151,6 +156,7 @@ const AssetSelector = observer(() => {
                         value={assetModalState.input}
                         onChange={e => onChange(e)}
                         placeholder="Search Token Name, Symbol, or Address"
+                        ref={inputRef}
                     />
                 </InputContainer>
                 <AssetOptions />

--- a/src/components/SlippageInfo.tsx
+++ b/src/components/SlippageInfo.tsx
@@ -3,7 +3,7 @@ import Popup from 'reactjs-popup';
 import styled from 'styled-components';
 import { observer } from 'mobx-react';
 import { useStores } from '../contexts/storesContext';
-import { InputValidationStatus } from '../stores/SwapForm';
+import { InputValidationStatus, SwapObjection } from '../stores/SwapForm';
 import { formatPctString, bnum } from '../utils/helpers';
 
 const SlippageInfoContainer = styled.div`
@@ -72,6 +72,9 @@ const SlippageInfo = observer(() => {
     } = swapFormStore;
 
     let slippageIndicator = false;
+
+    if (swapFormStore.outputs.swapObjection !== SwapObjection.NONE)
+        slippageIndicator = true;
 
     if (expectedSlippage > '5') {
         slippageIndicator = true;

--- a/src/components/TokenPanel.tsx
+++ b/src/components/TokenPanel.tsx
@@ -220,6 +220,10 @@ const Token = observer(
             );
         };
 
+        const IconError = e => {
+            e.target.src = './empty-token.png';
+        };
+
         return (
             <Panel>
                 <PanelHeader>{headerText}</PanelHeader>
@@ -229,7 +233,12 @@ const Token = observer(
                     }}
                 >
                     <IconAndNameContainer>
-                        <TokenIcon src={TokenIconAddress(tokenAddress)} />
+                        <TokenIcon
+                            src={TokenIconAddress(tokenAddress)}
+                            onError={e => {
+                                IconError(e);
+                            }}
+                        />
                         <TokenName>{tokenName}</TokenName>
                     </IconAndNameContainer>
                     <TokenBalance>

--- a/src/deployed.json
+++ b/src/deployed.json
@@ -9,14 +9,12 @@
             {
                 "symbol": "ETH",
                 "address": "ether",
-                "decimals": 18,
                 "iconAddress": "ether",
                 "precision": 4
             },
             {
                 "symbol": "DAI",
                 "address": "0xDc497593C97cf51aC80F1338bD20A7572B824646",
-                "decimals": 18,
                 "iconAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
                 "precision": 2
             }
@@ -32,77 +30,66 @@
             {
                 "symbol": "ETH",
                 "address": "ether",
-                "decimals": 18,
                 "iconAddress": "ether",
                 "precision": 4
             },
             {
                 "symbol": "DAI",
                 "address": "0x1528F3FCc26d13F7079325Fb78D9442607781c8C",
-                "decimals": 18,
                 "iconAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
                 "precision": 2
             },
             {
                 "symbol": "MKR",
                 "address": "0xef13C0c8abcaf5767160018d268f9697aE4f5375",
-                "decimals": 18,
                 "iconAddress": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
                 "precision": 4
             },
             {
                 "symbol": "USDC",
                 "address": "0x2F375e94FC336Cdec2Dc0cCB5277FE59CBf1cAe5",
-                "decimals": 6,
                 "iconAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                 "precision": 2
             },
             {
                 "symbol": "REP",
                 "address": "0x8c9e6c40d3402480ACE624730524fACC5482798c",
-                "decimals": 18,
                 "iconAddress": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
                 "precision": 4
             },
             {
                 "symbol": "WBTC",
                 "address": "0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb",
-                "decimals": 8,
                 "iconAddress": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
                 "precision": 4
             },
             {
                 "symbol": "WETH",
                 "address": "0xd0A1E359811322d97991E03f863a0C30C2cF029C",
-                "decimals": 18,
                 "iconAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
                 "precision": 4
             },
             {
                 "symbol": "BAT",
                 "address": "0x1f1f156E0317167c11Aa412E3d1435ea29Dc3cCE",
-                "decimals": 18,
                 "iconAddress": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
                 "precision": 2
             },
             {
                 "symbol": "SNX",
                 "address": "0x86436BcE20258a6DcfE48C9512d4d49A30C4d8c4",
-                "decimals": 18,
                 "iconAddress": "0xc011a72400e58ecd99ee497cf89e3775d4bd732f",
                 "precision": 2
             },
             {
                 "symbol": "ANT",
                 "address": "0x37f03a12241E9FD3658ad6777d289c3fb8512Bc9",
-                "decimals": 18,
                 "iconAddress": "0x960b236A07cf122663c4303350609A66A7B288C0",
                 "precision": 2
             },
             {
                 "symbol": "ZRX",
                 "address": "0xccb0F4Cf5D3F97f4a55bb5f5cA321C3ED033f244",
-                "decimals": 18,
                 "iconAddress": "0xe41d2489571d322189246dafa5ebde1f4699f498",
                 "precision": 2
             }
@@ -118,49 +105,42 @@
             {
                 "symbol": "ETH",
                 "address": "ether",
-                "decimals": 18,
                 "iconAddress": "ether",
                 "precision": 4
             },
             {
                 "symbol": "DAI",
                 "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-                "decimals": 18,
                 "iconAddress": "0x6b175474e89094c44da98b954eedeac495271d0f",
                 "precision": 2
             },
             {
                 "symbol": "MKR",
                 "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
-                "decimals": 18,
                 "iconAddress": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
                 "precision": 4
             },
             {
                 "symbol": "USDC",
                 "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-                "decimals": 6,
                 "iconAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
                 "precision": 2
             },
             {
                 "symbol": "tBTC",
                 "address": "0x1bBE271d15Bb64dF0bc6CD28Df9Ff322F2eBD847",
-                "decimals": 18,
                 "iconAddress": "0x1bBE271d15Bb64dF0bc6CD28Df9Ff322F2eBD847",
                 "precision": 6
             },
             {
                 "symbol": "REP",
                 "address": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
-                "decimals": 18,
                 "iconAddress": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
                 "precision": 4
             },
             {
                 "symbol": "BTC++",
                 "address": "0x0327112423F3A68efdF1fcF402F6c5CB9f7C33fd",
-                "decimals": 18,
                 "ticker": "BTC",
                 "precision": 6,
                 "iconAddress": "0x0327112423F3A68efdF1fcF402F6c5CB9f7C33fd"
@@ -168,168 +148,144 @@
             {
                 "symbol": "WBTC",
                 "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-                "decimals": 8,
                 "iconAddress": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
                 "precision": 4
             },
             {
                 "symbol": "WETH",
                 "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-                "decimals": 18,
                 "iconAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
                 "precision": 4
             },
             {
                 "symbol": "BAT",
                 "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
-                "decimals": 18,
                 "iconAddress": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
                 "precision": 2
             },
             {
                 "symbol": "SNX",
                 "address": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
-                "decimals": 18,
                 "iconAddress": "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F",
                 "precision": 2
             },
             {
                 "symbol": "ANT",
                 "address": "0x960b236A07cf122663c4303350609A66A7B288C0",
-                "decimals": 18,
                 "iconAddress": "0x960b236A07cf122663c4303350609A66A7B288C0",
                 "precision": 2
             },
             {
                 "symbol": "ZRX",
                 "address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
-                "decimals": 18,
                 "iconAddress": "0xe41d2489571d322189246dafa5ebde1f4699f498",
                 "precision": 2
             },
             {
                 "symbol": "LINK",
                 "address": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
-                "decimals": 18,
                 "iconAddress": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
                 "precision": 2
             },
             {
                 "symbol": "cUSDC",
                 "address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
-                "decimals": 8,
                 "iconAddress": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
                 "precision": 2
             },
             {
                 "symbol": "cDAI",
                 "address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
-                "decimals": 8,
                 "iconAddress": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
                 "precision": 2
             },
             {
                 "symbol": "imBTC",
                 "address": "0x3212b29E33587A00FB1C83346f5dBFA69A458923",
-                "decimals": 8,
                 "iconAddress": "0x3212b29E33587A00FB1C83346f5dBFA69A458923",
                 "precision": 4
             },
             {
                 "symbol": "pBTC",
                 "address": "0x5228a22e72ccC52d415EcFd199F99D0665E7733b",
-                "decimals": 18,
                 "iconAddress": "unknown",
                 "precision": 2
             },
             {
                 "symbol": "sBTC",
                 "address": "0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6",
-                "decimals": 18,
                 "iconAddress": "unknown",
                 "precision": 2
             },
             {
                 "symbol": "sUSD",
                 "address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
-                "decimals": 18,
                 "iconAddress": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
                 "precision": 2
             },
             {
                 "symbol": "DZAR",
                 "address": "0x9Cb2f26A23b8d89973F08c957C4d7cdf75CD341c",
-                "decimals": 6,
                 "iconAddress": "0x9Cb2f26A23b8d89973F08c957C4d7cdf75CD341c",
                 "precision": 2
             },
             {
                 "symbol": "UMA",
                 "address": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
-                "decimals": 18,
                 "iconAddress": "0x04Fa0d235C4abf4BcF4787aF4CF447DE572eF828",
                 "precision": 2
             },
             {
                 "symbol": "PNK",
                 "address": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
-                "decimals": 18,
                 "iconAddress": "0x93ED3FBe21207Ec2E8f2d3c3de6e058Cb73Bc04d",
                 "precision": 2
             },
             {
                 "symbol": "AST",
                 "address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
-                "decimals": 4,
                 "iconAddress": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
                 "precision": 2
             },
             {
                 "symbol": "LRC",
                 "address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
-                "decimals": 18,
                 "iconAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
                 "precision": 2
             },
             {
                 "symbol": "REN",
                 "address": "0x408e41876cCCDC0F92210600ef50372656052a38",
-                "decimals": 18,
                 "iconAddress": "0x408e41876cCCDC0F92210600ef50372656052a38",
                 "precision": 2
             },
             {
                 "symbol": "RPL",
                 "address": "0xB4EFd85c19999D84251304bDA99E90B92300Bd93",
-                "decimals": 18,
                 "iconAddress": "0xB4EFd85c19999D84251304bDA99E90B92300Bd93",
                 "precision": 2
             },
             {
                 "symbol": "LEND",
                 "address": "0x80fB784B7eD66730e8b1DBd9820aFD29931aab03",
-                "decimals": 18,
                 "iconAddress": "0x80fB784B7eD66730e8b1DBd9820aFD29931aab03",
                 "precision": 2
             },
             {
                 "symbol": "KNC",
                 "address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
-                "decimals": 18,
                 "iconAddress": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
                 "precision": 2
             },
             {
                 "symbol": "COMP",
                 "address": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
-                "decimals": 18,
                 "iconAddress": "0xc00e94Cb662C3520282E6f5717214004A7f26888",
                 "precision": 2
             },
             {
                 "symbol": "OCEAN",
                 "address": "0x985dd3D42De1e256d09e1c10F112bCCB8015AD41",
-                "decimals": 18,
                 "iconAddress": "0x985dd3D42De1e256d09e1c10F112bCCB8015AD41",
                 "precision": 2
             }

--- a/src/stores/ContractMetadata.ts
+++ b/src/stores/ContractMetadata.ts
@@ -155,4 +155,11 @@ export default class ContractMetadataStore {
             token => token.isSupported
         )[0].address;
     }
+
+    setTokenDecimals(address: string, decimals: number) {
+        const tokenUrl = this.contractMetadata.tokens.find(
+            t => t.address === address
+        );
+        if (tokenUrl) tokenUrl.decimals = decimals;
+    }
 }

--- a/src/stores/ContractMetadata.ts
+++ b/src/stores/ContractMetadata.ts
@@ -47,11 +47,11 @@ export default class ContractMetadataStore {
         };
 
         tokenMetadata.forEach(token => {
-            const { address, symbol, decimals, iconAddress, precision } = token;
+            const { address, symbol, iconAddress, precision } = token;
             contractMetadata.tokens.push({
                 address,
                 symbol,
-                decimals,
+                decimals: undefined,
                 iconAddress,
                 precision,
                 isSupported: true,

--- a/src/stores/Token.ts
+++ b/src/stores/Token.ts
@@ -333,7 +333,7 @@ export default class TokenStore {
                 [balBlock, mulBalance],
                 [allBlock, mulAllowance],
                 mulEth,
-                [mulDecimals],
+                [, mulDecimals],
             ] = await Promise.all(promises);
             const balances = mulBalance.map(value =>
                 bnum(iface.functions.balanceOf.decode(value))

--- a/src/stores/Token.ts
+++ b/src/stores/Token.ts
@@ -333,7 +333,7 @@ export default class TokenStore {
                 [balBlock, mulBalance],
                 [allBlock, mulAllowance],
                 mulEth,
-                [decBlock, mulDecimals],
+                [mulDecimals],
             ] = await Promise.all(promises);
             const balances = mulBalance.map(value =>
                 bnum(iface.functions.balanceOf.decode(value))

--- a/src/stores/Token.ts
+++ b/src/stores/Token.ts
@@ -213,6 +213,23 @@ export default class TokenStore {
         };
     }
 
+    private setDecimals(tokens: string[], decimals: number[]) {
+        const { contractMetadataStore } = this.rootStore;
+
+        let index = 0;
+        tokens.forEach(tokenAddr => {
+            if (tokenAddr === EtherKey) {
+                contractMetadataStore.setTokenDecimals(tokenAddr, 18);
+            } else {
+                contractMetadataStore.setTokenDecimals(
+                    tokenAddr,
+                    decimals[index]
+                );
+                index += 1;
+            }
+        });
+    }
+
     getBalance(tokenAddress: string, account: string): BigNumber | undefined {
         const chainBalances = this.balances;
         if (chainBalances) {
@@ -273,6 +290,7 @@ export default class TokenStore {
         const promises: Promise<any>[] = [];
         const balanceCalls = [];
         const allowanceCalls = [];
+        const decimalsCalls = [];
         const tokenList = [];
 
         const multiAddress = contractMetadataStore.getMultiAddress();
@@ -297,18 +315,25 @@ export default class TokenStore {
                         contractMetadataStore.getProxyAddress(),
                     ]),
                 ]);
+
+                decimalsCalls.push([
+                    address,
+                    iface.functions.decimals.encode([]),
+                ]);
             }
         });
 
         promises.push(multi.aggregate(balanceCalls));
         promises.push(multi.aggregate(allowanceCalls));
         promises.push(multi.getEthBalance(account));
+        promises.push(multi.aggregate(decimalsCalls));
 
         try {
             const [
                 [balBlock, mulBalance],
                 [allBlock, mulAllowance],
                 mulEth,
+                [decBlock, mulDecimals],
             ] = await Promise.all(promises);
             const balances = mulBalance.map(value =>
                 bnum(iface.functions.balanceOf.decode(value))
@@ -322,6 +347,10 @@ export default class TokenStore {
             balances.unshift(ethBalance);
             allowances.unshift(bnum(helpers.setPropertyToMaxUintIfEmpty()));
 
+            const decimalsList = mulDecimals.map(value =>
+                bnum(iface.functions.decimals.decode(value))
+            );
+
             this.setBalances(tokenList, balances, account, balBlock.toNumber());
 
             this.setAllowances(
@@ -331,6 +360,8 @@ export default class TokenStore {
                 allowances,
                 allBlock.toNumber()
             );
+
+            this.setDecimals(tokenList, decimalsList);
 
             console.debug('[All Fetches Success]');
         } catch (e) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4682,6 +4682,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-browser@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.1.1.tgz#a800db91d3fd60d0861669f5984f1be9ffbe009c"
+  integrity sha512-5n2aWI57qC3kZaK4j2zYsG6L1LrxgLptGCNhMQgdKhVn6cSdcq43pp6xHPfTHG3TYM6myF4tIPWiZtfdVDgb9w==
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -13157,11 +13162,12 @@ web3-provider-engine@15.0.4:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3modal@^1.2.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/web3modal/-/web3modal-1.5.0.tgz#e0562523fe9abd2afb7e7a9714e532cefae08f37"
-  integrity sha512-ylh/uhcjJ5Z6uXCv//EdeouemuLYijWptosde2wa2G6hr3A0BOJR9Gk2bPrkQ7h/dpYLYAS6/4Oay27I8sep2Q==
+web3modal@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/web3modal/-/web3modal-1.7.0.tgz#21b424325e6e4221d7ffaaaa11632e80d9204bf9"
+  integrity sha512-OHkoHIrP7NLu41N8GJfaaV1/z7Si7pP65jJq7fC+DIwfLa8URWqyvRvhD95ChgTVi0w5nEp18IYuqONFR6KTcQ==
   dependencies:
+    detect-browser "^5.1.0"
     prop-types "^15.7.2"
     react "^16.8.6"
     react-dom "^16.8.6"


### PR DESCRIPTION
Additions for BALS-76, 61, 97, 103, 7 & 30. 
Web3modal verison has been bumped to 1.7.0.
Token decimals removed from deployed.json and retrieved via on-chain during multicall for balances, etc.
On-chain balances (and weights and fee) used for Subgraph pool info.