### PR TITLE
Improve token amount input truncation

### DIFF
--- a/src/components/TokenPanel.tsx
+++ b/src/components/TokenPanel.tsx
@@ -105,7 +105,7 @@ const InputWrapper = styled.div`
     border-top: 1px solid var(--panel-border);
     border-radius: 0px 0px 4px 4px;
     input {
-        width: 100px;
+        width: 100%;
         color: var(--input-text);
         font-size: 16px;
         font-weight: 500;

--- a/src/components/TokenPanel.tsx
+++ b/src/components/TokenPanel.tsx
@@ -106,6 +106,7 @@ const InputWrapper = styled.div`
     border-radius: 0px 0px 4px 4px;
     input {
         width: 100%;
+        text-overflow: ellipsis;
         color: var(--input-text);
         font-size: 16px;
         font-weight: 500;


### PR DESCRIPTION
It's very unlikely that the calculated output of a trade will terminate in a short number of decimal places so in the vast majority of trades some decimals are truncated. This results in an unceremonious cutting in half of a number as below.

![Screenshot_2020-07-13_17-43-27](https://user-images.githubusercontent.com/15848336/87330506-94933980-c530-11ea-8b87-0e1f8ed3b158.png)

I've added some css to mean that instead some ellipses are added signalling the overflow.

![Screenshot_2020-07-13_17-46-43](https://user-images.githubusercontent.com/15848336/87330677-d7eda800-c530-11ea-843d-d82bed8978e1.png)

I've also modified the input such that it fills the full container's width. This means that in the case that the max button isn't shown, that area may be used for displaying more digits.