### PR TITLE
add GRG token

### DIFF
--- a/src/deployed.json
+++ b/src/deployed.json
@@ -325,6 +325,12 @@
                 "address": "0x81ab848898b5ffD3354dbbEfb333D5D183eEDcB5",
                 "iconAddress": "unknown",
                 "precision": 2
+            },
+            {
+                "symbol": "GRG",
+                "address": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
+                "iconAddress": "0x4fbb350052bca5417566f188eb2ebce5b19bc964",
+                "precision": 2
             }
         ]
     }


### PR DESCRIPTION
GRG is already whitelisted for BAL liquidity mining and I would kindly ask for it to being added to the default token list, if deemed appropriate.