### PR TITLE
set inputmode to decimal/number for token amounts in the swap fields

### DIFF
--- a/src/components/TokenPanel.tsx
+++ b/src/components/TokenPanel.tsx
@@ -104,6 +104,14 @@ const InputWrapper = styled.div`
     padding-right: 21px;
     border-top: 1px solid var(--panel-border);
     border-radius: 0px 0px 4px 4px;
+    input[type="number"] {
+        -moz-appearance: textfield;
+    }
+        input[type="number"]::-webkit-inner-spin-button,
+        input[type="number"]::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+    }
     input {
         width: 100px;
         color: var(--input-text);
@@ -204,6 +212,8 @@ const Token = observer(
                         onChange={onChange}
                         ref={textInput}
                         placeholder="0"
+                        inputMode="decimal"
+                        type="number"
                     />
                     {(tokenAddress === EtherKey &&
                         modalType === ModalType.INPUT) ||


### PR DESCRIPTION
This makes the swap form less of a pain to use on mobile (don't need to swap to number mode when entering amounts manually). I don't see a test suite so I did a few quick manual tests on ios and android and it doesn't seem to break anything obvious.

### Before
![2020-07-27 12 32 09](https://user-images.githubusercontent.com/1150253/88507701-84696880-cfcc-11ea-81b2-9cbb86213c69.png)



### After
![2020-07-27 12 31 59](https://user-images.githubusercontent.com/1150253/88507703-86cbc280-cfcc-11ea-8a19-18add7726fdd.png)

