### PR TITLE
fix: prevent broken display AssetPanel on smaller screen sizes

### DIFF
--- a/src/components/AssetOptions.tsx
+++ b/src/components/AssetOptions.tsx
@@ -21,10 +21,11 @@ const AssetPanelContainer = styled.div`
 
 const AssetPanel = styled.div`
     display: flex;
+    flex-grow: 1
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    width: 184px;
+    width: 33%;
     height: 98px;
     cursor: pointer;
     border-right: 1px solid var(--panel-border);


### PR DESCRIPTION
Due to the AssetPanels having a fixed width they break when their container isn't the expected size (see below): 
![image](https://user-images.githubusercontent.com/15848336/88552967-9e329c00-d01c-11ea-8a8c-5ca69742245f.png)

I've updated them to fill a third of the container and allowed them to grow to fill the remaining 1%. The result is that the AssetPanels display properly for all relevant sizes.