### PR TITLE
Update Transaction.js to fix chain id

### DIFF
--- a/src/components/WalletDropdown/Transaction.js
+++ b/src/components/WalletDropdown/Transaction.js
@@ -66,7 +66,7 @@ export default function Transaction({ hash, pending }) {
         root: { providerStore },
     } = useStores();
 
-    const chainId = providerStore.providerStatus.chainId;
+    const chainId = providerStore.providerStatus.activeChainId;
 
     return (
         <TransactionWrapper key={hash}>


### PR DESCRIPTION
ProviderStatus contains a property for activeChainId not chainId. 

This bug causes the getEtherscanLink method's networkId to be undefined, so main-net is forced even if Kovan or another test-net is used.

This issue can be reproduced by going to: https://kovan.balancer.exchange, creating a swap/transaction, clicking your wallet in the top right and clicking one of the transactions, you will see you are redirected to etherscan main-net instead of etherscan Kovan.

This PR fixes this issue and allows you to go to your selected etherscan main-net/test-net when a transaction is clicked.