### PR TITLE
Use logo mapping from assets repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@typescript-eslint/eslint-plugin": "^2.2.0",
         "@typescript-eslint/parser": "^2.2.0",
         "@walletconnect/web3-provider": "^1.2.1",
-        "assets": "github:balancer-labs/assets",
+        "@balancer-labs/assets": "github:balancer-labs/assets",
         "babel-eslint": "10.0.3",
         "babel-jest": "^24.9.0",
         "babel-loader": "8.0.6",

--- a/src/components/TokenPanel.tsx
+++ b/src/components/TokenPanel.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
+import logos from '@balancer-labs/assets/assets/index.json';
 import { isAddress } from '../utils/helpers';
 import { EtherKey } from '../stores/Token';
 import { ModalType } from '../stores/SwapForm';
 import { observer } from 'mobx-react';
 import { useStores } from '../contexts/storesContext';
-import logos from '../utils/logos.json';
 
 const Panel = styled.div`
     width: 180px;

--- a/src/configs/addresses.ts
+++ b/src/configs/addresses.ts
@@ -1,5 +1,5 @@
-import registry from 'assets/generated/dex/registry.homestead.json';
-import registryKovan from 'assets/generated/dex/registry.kovan.json';
+import registry from '@balancer-labs/assets/generated/dex/registry.homestead.json';
+import registryKovan from '@balancer-labs/assets/generated/dex/registry.kovan.json';
 import { getSupportedChainName } from '../provider/connectors';
 
 function getContracts(chainName: string) {

--- a/src/utils/logos.json
+++ b/src/utils/logos.json
@@ -1,4 +1,0 @@
-[
-  "0xad32a8e6220741182940c5abf610bde99e737b2d",
-  "0xad6a626ae2b43dcb1b39430ce496d2fa0365ba9c"
-]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1832,6 +1832,10 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@balancer-labs/assets@github:balancer-labs/assets":
+  version "1.0.0"
+  resolved "https://codeload.github.com/balancer-labs/assets/tar.gz/8998629180bc8e1846c9b528a38f6abdf2dc47c5"
+
 "@balancer-labs/sor@0.4.0-6":
   version "0.4.0-6"
   resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-0.4.0-6.tgz#2c0d52b6ca58785c493f17b18f86aa614408f7e7"
@@ -3067,10 +3071,6 @@ assert@^1.1.1:
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
-
-"assets@github:balancer-labs/assets":
-  version "1.0.0"
-  resolved "https://codeload.github.com/balancer-labs/assets/tar.gz/master"
 
 assign-symbols@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Changes:

- Use logo mapping from assets repo
- Change the name of the module "assets" to "@balancer-labs/assets" because it was conflicting with the local "assets" folder in the "src" folder.