### PR TITLE
refactor: standardise subgraph urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,9 @@
-SUBGRAPH_URL=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan
 
-# Currently unused
-SUBGRAPH_URL_1={mainnet-subgraph}
-SUBGRAPH_URL_42={kovan-subgraph}
-SUBGRAPH_URL_LOCAL={local-subgraph}
-
-# Required for SOR defaults to mainnet
-REACT_APP_SUBGRAPH_URL={subgraph url for network}
+# Subgraph URL
+REACT_APP_SUBGRAPH_URL_1=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer
+REACT_APP_SUBGRAPH_URL_3=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-ropsten
+REACT_APP_SUBGRAPH_URL_4=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-rinkeby
+REACT_APP_SUBGRAPH_URL_42=https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan
 
 # Backup node url
 REACT_APP_RPC_URL_1="https://mainnet.infura.io/v3/{apiKey}"

--- a/src/provider/connectors.ts
+++ b/src/provider/connectors.ts
@@ -62,6 +62,9 @@ export const SUBGRAPH_URLS: { [chainId: number]: string } = {
     42: process.env.REACT_APP_SUBGRAPH_URL_42 as string,
 };
 
+export const SUBGRAPH_URL =
+    SUBGRAPH_URLS[process.env.REACT_APP_SUPPORTED_NETWORK_ID];
+
 export const backupUrls = {};
 backupUrls[supportedChainId] = RPC_URLS[supportedChainId];
 

--- a/src/utils/subGraph.ts
+++ b/src/utils/subGraph.ts
@@ -1,9 +1,6 @@
 import fetch from 'isomorphic-fetch';
 import * as allPools from 'allPublicPools.json';
-
-const SUBGRAPH_URL =
-    process.env.REACT_APP_SUBGRAPH_URL ||
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer';
+import { SUBGRAPH_URL } from 'provider/connectors';
 
 // Returns all public pools
 export async function getAllPublicSwapPools() {


### PR DESCRIPTION
There seems to be multiple competing places where the subgraph url has been stored. I've removed the other environment variables other than `REACT_APP_SUBGRAPH_URL_X` and exported the relevant url for the chosen network from `providers/connectors` as `SUBGRAPH_URL`